### PR TITLE
Update yuzu-mainline-git PKGBUILD to follow arch wiki pkgbuild guideline

### DIFF
--- a/yuzu-mainline-git/interfere.patch
+++ b/yuzu-mainline-git/interfere.patch
@@ -1,0 +1,29 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 3b7ba10..aead7e2 100755
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -42,6 +42,7 @@ source=("$_pkgname::git+https://github.com/yuzu-emu/yuzu-mainline"
+         'git+https://github.com/xiph/opus.git'
+         'git+https://git.ffmpeg.org/ffmpeg.git'
+         'git+https://github.com/libsdl-org/SDL.git'
++        'git+https://github.com/yhirose/cpp-httplib.git'
+         # cubeb dependencies
+         'git+https://github.com/arsenm/sanitizers-cmake.git'
+         # sirit dependencies
+@@ -63,6 +64,7 @@ md5sums=('SKIP'
+          'SKIP'
+          'SKIP'
+          'SKIP'
++         'SKIP'
+          'SKIP')
+ 
+ pkgver() {
+@@ -73,7 +75,7 @@ pkgver() {
+ prepare() {
+     cd "$srcdir/$_pkgname"
+ 
+-    for submodule in externals/{inih/inih,cubeb,dynarmic,soundtouch,libressl,libusb/libusb,discord-rpc,Vulkan-Headers,sirit,mbedtls,libzip/libzip,xbyak,opus/opus,ffmpeg,SDL}; do
++    for submodule in externals/{inih/inih,cubeb,dynarmic,soundtouch,libressl,libusb/libusb,discord-rpc,Vulkan-Headers,sirit,mbedtls,libzip/libzip,xbyak,opus/opus,ffmpeg,SDL,cpp-httplib}; do
+         git submodule init ${submodule}
+         git config submodule.${submodule}.url "$srcdir/${submodule##*/}"
+         git submodule update


### PR DESCRIPTION
* Use boost/boost-libs from system instead of using the bundled one
* Set CMAKE_BUILD_TYPE to None to use -O2 as specified in makepkg.conf
