### PR TITLE
Fix switching from sip4 to sip to make packages build

### DIFF
--- a/kauth-git/PKGBUILD.append
+++ b/kauth-git/PKGBUILD.append
@@ -1,0 +1,1 @@
+makedepends=(git extra-cmake-modules-git qt5-tools clang python-pyqt5 doxygen sip)

--- a/kcodecs-git/PKGBUILD.append
+++ b/kcodecs-git/PKGBUILD.append
@@ -1,4 +1,4 @@
-makedepends=(git extra-cmake-modules-git qt5-tools clang python-pyqt5 gperf doxygen sip4)
+makedepends=(git extra-cmake-modules-git qt5-tools clang python-pyqt5 gperf doxygen sip)
 
 pkgver() {
   cd ${pkgname%-git}

--- a/kcompletion-git/PKGBUILD.append
+++ b/kcompletion-git/PKGBUILD.append
@@ -1,0 +1,1 @@
+makedepends=(git extra-cmake-modules-git qt5-tools clang python-pyqt5 doxygen sip)

--- a/kconfig-git/PKGBUILD.append
+++ b/kconfig-git/PKGBUILD.append
@@ -1,0 +1,1 @@
+makedepends=(git extra-cmake-modules-git qt5-tools clang python-pyqt5 doxygen sip)

--- a/kconfigwidgets-git/PKGBUILD.append
+++ b/kconfigwidgets-git/PKGBUILD.append
@@ -1,0 +1,1 @@
+makedepends=(git extra-cmake-modules-git kdoctools-git clang python-pyqt5 doxygen qt5-tools sip)

--- a/kcoreaddons-git/PKGBUILD.append
+++ b/kcoreaddons-git/PKGBUILD.append
@@ -1,0 +1,1 @@
+makedepends=(git extra-cmake-modules-git qt5-tools clang python-pyqt5 doxygen sip)

--- a/kdbusaddons-git/PKGBUILD.append
+++ b/kdbusaddons-git/PKGBUILD.append
@@ -1,0 +1,1 @@
+makedepends=(git extra-cmake-modules-git qt5-tools clang python-pyqt5 doxygen sip)

--- a/kguiaddons-git/PKGBUILD.append
+++ b/kguiaddons-git/PKGBUILD.append
@@ -1,0 +1,1 @@
+makedepends=(git extra-cmake-modules-git clang python-pyqt5 doxygen qt5-tools sip)

--- a/ki18n-git/PKGBUILD.append
+++ b/ki18n-git/PKGBUILD.append
@@ -1,0 +1,1 @@
+makedepends=(git extra-cmake-modules-git qt5-declarative python-pyqt5 clang doxygen qt5-tools sip)

--- a/kitemmodels-git/PKGBUILD.append
+++ b/kitemmodels-git/PKGBUILD.append
@@ -1,0 +1,1 @@
+makedepends=(git extra-cmake-modules-git python-pyqt5 clang doxygen qt5-tools sip qt5-declarative)

--- a/kitemviews-git/PKGBUILD.append
+++ b/kitemviews-git/PKGBUILD.append
@@ -1,0 +1,1 @@
+makedepends=(git extra-cmake-modules-git qt5-tools clang python-pyqt5 doxygen sip)

--- a/kjobwidgets-git/PKGBUILD.append
+++ b/kjobwidgets-git/PKGBUILD.append
@@ -1,0 +1,1 @@
+makedepends=(git extra-cmake-modules-git qt5-tools clang python-pyqt5 doxygen sip)

--- a/kwidgetsaddons-git/PKGBUILD.append
+++ b/kwidgetsaddons-git/PKGBUILD.append
@@ -1,0 +1,1 @@
+makedepends=(git extra-cmake-modules-git qt5-tools clang python-pyqt5 doxygen sip)


### PR DESCRIPTION
All dependencies are the same, except sip4 that got switched to sip