### PR TITLE
Fix missing files on install phase

### DIFF
--- a/kimageannotator-git/PKGBUILD.append
+++ b/kimageannotator-git/PKGBUILD.append
@@ -1,0 +1,7 @@
+package(){
+    cd ${pkgname%-git}/build
+    make DESTDIR="$pkgdir" install
+    cd "$pkgdir"/usr
+    install -dm755 bin
+    #install -Dm544 "$srcdir/kImageAnnotator/build/example/kImageAnnotator-example" bin/kImageAnnotator-example
+}

--- a/kimageformats-git/PKGBUILD.append
+++ b/kimageformats-git/PKGBUILD.append
@@ -1,0 +1,5 @@
+package() {
+    cd $srcdir/$_pkgname/build
+    make DESTDIR="$pkgdir" install
+    #install -Dm644 ../COPYING.LIB "$pkgdir/usr/share/licenses/$_pkgname/LICENSE"
+}


### PR DESCRIPTION
Removes the installation of some missing files
from:
	kimageannotator-git
	kimageformats-git

The install function is the same, except the missing files commented