### PR TITLE
proper fix for pkgver on kapidox

### DIFF
--- a/kapidox-git/PKGBUILD.append
+++ b/kapidox-git/PKGBUILD.append
@@ -1,6 +1,6 @@
 pkgver() {
   cd ${pkgname%-git}
-  _ver="$(grep -m1 'set(PROJECT_VERSION' CMakeLists.txt | cut -d '"' -f2 | tr - .)"
+  _ver="$(grep -m1 'version=' setup.py | cut -d'=' -f2 | cut -c 2- | rev | cut -c 3- | rev | tr - .)"
   echo "${_ver}_r$(git rev-list --count HEAD).g$(git rev-parse --short HEAD)"
 }
 


### PR DESCRIPTION
resulted in package on chaotic:

'./kapidox-git-5.91.0_r562.gc93e657-1-any.pkg.tar.zst'