### PR TITLE
try to fix kapidox-git failing to build

### DIFF
--- a/kapidox-git/PKGBUILD.append
+++ b/kapidox-git/PKGBUILD.append
@@ -4,8 +4,12 @@ pkgver() {
   echo "${_ver}_r$(git rev-list --count HEAD).g$(git rev-parse --short HEAD)"
 }
 
+build() {  
+  cmake -B build -S $_pkgname \
+    -DCMAKE_INSTALL_PREFIX=/usr
+  cmake --build build
+}
+
 package() {
-  cd $srcdir/$_pkgname/build
-  make DESTDIR="$pkgdir" install
-  #install -Dm644 ../LICENSE "$pkgdir/usr/share/licenses/$_pkgname/LICENSE"
+  DESTDIR="$pkgdir" cmake --install build
 }


### PR DESCRIPTION
tested on latest build of kapidox-git-5.93.0_r566.gd385445-1-any.pkg.tar.zst , seems to be fixing it.