### PR TITLE
Strangely the last commit is breaking konsole

### DIFF
--- a/plasma-integration-git/PKGBUILD.append
+++ b/plasma-integration-git/PKGBUILD.append
@@ -1,0 +1,1 @@
+source=("git+https://github.com/KDE/${pkgname%-git}.git#commit=2b406a9df8e21a179f3b8cb03c8dbb5d50124a32")


### PR DESCRIPTION
Hopefully temporary solution so that we can use plasma-integration-git and konsole at the same time.

As it is, konsole doesn't launch.