### PR TITLE
proper pull request of plasma-integration-git

### DIFF
--- a/plasma-integration-git/PKGBUILD.append
+++ b/plasma-integration-git/PKGBUILD.append
@@ -1,0 +1,3 @@
+depends+=(plasma-wayland-protocols-git)
+
+source=("git+https://github.com/KDE/${pkgname%-git}.git#commit=61345d47804f182d2d4e7b4db8510b081ab87034")


### PR DESCRIPTION
the depends line fixed the build. it needs plasma-wayland-protocols-git to build latest version.

but unfortunatly, have to use the previous commit before latest version, since it makes konsole not start. ( hence the source interference )