### PR TITLE
fix build: missing plasma-wayland-protocol dependency

### DIFF
--- a/kguiaddons-git/PKGBUILD.append
+++ b/kguiaddons-git/PKGBUILD.append
@@ -1,3 +1,6 @@
+
+depends+=(plasma-wayland-protocols-git)
+
 build() {
   cmake -B build -S ${pkgname%-git} \
     -DBUILD_TESTING=OFF \


### PR DESCRIPTION
Tested building manually, and builds successfully with added dependency