### PR TITLE
Drop mutter-performance interfere

### DIFF
--- a/mutter-performance/PKGBUILD.append
+++ b/mutter-performance/PKGBUILD.append
@@ -1,3 +1,0 @@
-check() {
-    echo "Removed as build breaking"
-}


### PR DESCRIPTION
* The `check()` operation is disabled by default in upstream now.
* (unless users explicitly tell to do so.) 
* Reference: https://aur.archlinux.org/cgit/aur.git/commit/?h=mutter-performance&id=bb7a3560f403b1a367c1058de95a35f1017237ae