### PR TITLE
Drop interfere for python-poetry-core-git

### DIFF
--- a/python-poetry-core-git/PKGBUILD.append
+++ b/python-poetry-core-git/PKGBUILD.append
@@ -1,5 +1,0 @@
-makedepends=(python-virtualenv python-dephell)
-
-check() {
-    echo "Removed as build breaking"
-}


### PR DESCRIPTION
Interfere was blocking `python-poetry-core-git` and `python-poetry-git` from building.

Some cleanup would be nice before reintroducing `python-poetry-*-git` to chaotic. 