### PR TITLE
Remove interferes for dropped python- packages

### DIFF
--- a/python-awesometkinter/PKGBUILD.append
+++ b/python-awesometkinter/PKGBUILD.append
@@ -1,1 +1,0 @@
-depends+=(python-setuptools)

--- a/python-constraint/PKGBUILD.append
+++ b/python-constraint/PKGBUILD.append
@@ -1,1 +1,0 @@
-makedepends+=(python-setuptools)

--- a/python-fastdtw/PKGBUILD.append
+++ b/python-fastdtw/PKGBUILD.append
@@ -1,1 +1,0 @@
-makedepends+=(python-pip)

--- a/python-fontparts/PKGBUILD.append
+++ b/python-fontparts/PKGBUILD.append
@@ -1,1 +1,0 @@
-makedepends+=('python-wheel' 'python-pip')

--- a/python-pyscf/PKGBUILD.append
+++ b/python-pyscf/PKGBUILD.append
@@ -1,1 +1,0 @@
-makedepends+=(python-setuptools git)

--- a/python-symdom-git/PKGBUILD.append
+++ b/python-symdom-git/PKGBUILD.append
@@ -1,1 +1,0 @@
-makedepends+=(cmake)

--- a/python-urlgrabber/PKGBUILD.append
+++ b/python-urlgrabber/PKGBUILD.append
@@ -1,2 +1,0 @@
-makedepends+=(python-pip python-wheel)
-replaces=(urlgrabber)


### PR DESCRIPTION
These interferes are no longer needed because  the underlying packages have been dropped from chaotic.

* python-awesometkinter
* python-constraint
* python-fastdtw
* python-fontparts
* python-pyscf
* python-symdom-git
* python-urlgrabber

Related https://github.com/chaotic-aur/graveyard/issues/373