### PR TITLE
Remove interfere for hal-git

### DIFF
--- a/hal-git/PKGBUILD.append
+++ b/hal-git/PKGBUILD.append
@@ -1,1 +1,0 @@
-makedepends+=('z3')


### PR DESCRIPTION
No longer needed because AUR dependencies were updated.

https://github.com/chaotic-aur/graveyard/issues/373