### PR TITLE
drop interfere for shadowsocks-rust-git

### DIFF
--- a/shadowsocks-rust-git/prepare
+++ b/shadowsocks-rust-git/prepare
@@ -1,2 +1,0 @@
-#!/usr/bin/env sh
-$CAUR_PUSH 'yes | pacman -S rust-nightly'


### PR DESCRIPTION
Was causing infinite loop that was preventing build.

See https://github.com/chaotic-aur/graveyard/issues/373