### PR TITLE
drop interfere for rofi-lbonn-wayland

### DIFF
--- a/rofi-lbonn-wayland/PKGBUILD.append
+++ b/rofi-lbonn-wayland/PKGBUILD.append
@@ -1,2 +1,0 @@
-makedepends+=(git)
-makedepends+=(ttf-font)


### PR DESCRIPTION
No longer needed.

See https://github.com/chaotic-aur/graveyard/issues/373