### PR TITLE
drop interfere for webkit2gtk-unstable

### DIFF
--- a/webkit2gtk-unstable/PKGBUILD.append
+++ b/webkit2gtk-unstable/PKGBUILD.append
@@ -1,1 +1,0 @@
-makedepends+=(wayland-protocols)


### PR DESCRIPTION
missing dependency was added upstream

See https://github.com/chaotic-aur/graveyard/issues/373