### PR TITLE
add interfere for mindustry-git

### DIFF
--- a/mindustry-git/PKGBUILD.append
+++ b/mindustry-git/PKGBUILD.append
@@ -1,0 +1,19 @@
+# mindustry-git does not currently build with jdk > 19,
+# so need to set java-environment to a supported version.
+
+makedepends=(${makedepends[@]/java-environment})
+makedepends+=(java-environment=17)
+
+
+# mindustry-git is able to run with jdk > 19,
+# so java-runtime can remain unversioned inside package
+
+depends=(${depends[@]/java-runtime})
+
+eval _orig_"$(declare -f package)"
+
+package() {
+  depends+=(java-runtime)
+
+  _orig_package
+}


### PR DESCRIPTION
`mindustry-git` can run, but not build, with jdk > 19.  This interfere sets `java-environment=17` (`makedepends`), which is available in `extra`.  `java-runtime` (`depends`) can remain unversioned when moved inside `package()`.