### PR TITLE
Remove papirus-folders-gui, php80, woof-git

### DIFF
--- a/papirus-folders-gui/PKGBUILD.append
+++ b/papirus-folders-gui/PKGBUILD.append
@@ -1,1 +1,0 @@
-makedepends+=(qt5-tools)

--- a/php80/prepare
+++ b/php80/prepare
@@ -1,2 +1,0 @@
-#!/usr/bin/env sh
-export TARGET_ARGS="--nocheck ${TARGET_ARGS:-}"

--- a/woof-git/PKGBUILD.append
+++ b/woof-git/PKGBUILD.append
@@ -1,1 +1,0 @@
-makedepends+=(python)


### PR DESCRIPTION
Interferes no longer needed because packages have been dropped.

* papirus-folders-gui
* php80
* woof-git

See https://github.com/chaotic-aur/graveyard/issues/373