### PR TITLE
make ytmdl interfere more robust

### DIFF
--- a/ytmdl/PKGBUILD.append
+++ b/ytmdl/PKGBUILD.append
@@ -1,25 +1,28 @@
-# fix prepare on version changes
-# 
-# 2023.2.28
+if [ "x$pkgrel" == "x0" ] ; then
+  pkgrel=1
+fi
 
 depends=(
-  "downloader-cli"
   "python-beautifulsoup4"
-  "python-ffmpeg"
-  "python-itunespy"
   "python-musicbrainzngs"
   "python-mutagen"
-  "python-pydes"
   "python-pyxdg"
   "python-rich"
-  "python-simber"
-  "python-spotipy"
   "python-unidecode"
   "python-urllib3"
   "python-ytmusicapi"
-  "youtube-search-python"
   "yt-dlp"
 
+  # AUR
+  "downloader-cli"
+  "python-ffmpeg"
+  "python-itunespy"
+  "python-pydes"
+  "python-simber"
+  "python-spotipy"
+  "youtube-search-python"
+
+  # Unnecessary
   #"python-brotli"
   #"python-pycryptodomex"
   #"python-pysocks"
@@ -34,19 +37,15 @@ makedepends=(
   "python-wheel"
 )
 
-conflicts=(${provides[@]})
-
 prepare() {
   cd "$pkgname-$pkgver"
-  sed -i 's|etc/bash_completion.d|share/completions|' setup.py
-  sed -i 's|usr/share/zsh/functions/Completion/Unix|share/completions|' setup.py
-
-  sed -i '14,32d' setup.py
+  mv "ytmdl.bash" "_ytmdl.bash"
+  mv "ytmdl.zsh" "_ytmdl.zsh"
 }
 
 build() {
   cd "$pkgname-$pkgver"
-  python -m build --no-isolation --wheel
+  python -m build --no-isolation --wheel --skip-dependency-check
 }
 
 package() {
@@ -55,13 +54,6 @@ package() {
 
   install -Dm664 LICENSE -t "$pkgdir/usr/share/licenses/$pkgname"
 
-  install -Dm644 \
-    "$pkgdir/usr/lib"/python*/"site-packages/share/completions/ytmdl.zsh" \
-    "$pkgdir/usr/share/zsh/site-functions/_ytmdl"
-
-  install -Dm644 \
-    "$pkgdir/usr/lib"/python*/"site-packages/share/completions/ytmdl.bash" \
-    "$pkgdir/usr/share/bash-completion/completions/ytmdl"
-
-  rm -rf "$pkgdir/usr/lib"/python*/"site-packages/share"
+  install -Dm644 "_ytmdl.bash" "$pkgdir/usr/share/bash-completion/completions/ytmdl"
+  install -Dm644 "_ytmdl.zsh" "$pkgdir/usr/share/zsh/site-functions/_ytmdl"
 }


### PR DESCRIPTION
Should be less likely to need update after version change.  No more `sed`.  No more moving and deleting files in `$pkgdir`.