### PR TITLE
Drop unnecessary interferes

### DIFF
--- a/cachyos-ananicy-rules/PKGBUILD.append
+++ b/cachyos-ananicy-rules/PKGBUILD.append
@@ -1,4 +1,0 @@
-pkgname=ananicy-rules
-pkgdesc='CachyOS - Ananicy rules'
-makedepends=(git)
-source=("${_gitname}::git+https://github.com/CachyOS/${_gitname}.git")

--- a/gdm-plymouth/prepare
+++ b/gdm-plymouth/prepare
@@ -1,2 +1,0 @@
-#!/usr/bin/env sh
-sed -i 's& groups=(gnome)&&'  PKGBUILD

--- a/pacman-auto-update/PKGBUILD.append
+++ b/pacman-auto-update/PKGBUILD.append
@@ -1,1 +1,0 @@
-makedepends+=(git)

--- a/pokete-git/PKGBUILD.append
+++ b/pokete-git/PKGBUILD.append
@@ -1,1 +1,0 @@
-depends+=(alsa-lib)

--- a/scrap_engine-git/PKGBUILD.append
+++ b/scrap_engine-git/PKGBUILD.append
@@ -1,1 +1,0 @@
-makedepends+=(python-pip)


### PR DESCRIPTION
Interferes no longer needed:

* cachyos-ananicy-rules # dropped from chaotic
* gdm-plymouth # dropped from chaotic
* pacman-auto-update # dropped from chaotic
* pokete-git # upstream fixed
* scrap_engine-git # upstream fixed

See https://github.com/chaotic-aur/graveyard/issues/373