### PR TITLE
Drop interfere for tenacity-git

### DIFF
--- a/tenacity-git/PKGBUILD.append
+++ b/tenacity-git/PKGBUILD.append
@@ -1,1 +1,0 @@
-makedepends+=(python)


### PR DESCRIPTION
No longer needed because changes were implemented upstream.

See https://github.com/chaotic-aur/graveyard/issues/373