### PR TITLE
Fix replaces for kf6-servicemenus-rootactions

### DIFF
--- a/kf6-servicemenus-rootactions/PKGBUILD.append
+++ b/kf6-servicemenus-rootactions/PKGBUILD.append
@@ -1,0 +1,1 @@
+replaces=(kf5-servicemenus-rootactions kde-servicemenus-rootactions)


### PR DESCRIPTION
Readd replaces for kf6-servicemenus-rootactions that are removed by default. For context see further discussion [here](https://forum.garudalinux.org/t/root-actions-menu-gone-in-plasma-6/35301/15).